### PR TITLE
corrected comment 'so that String and Substring behave largely the same.'

### DIFF
--- a/Whats-new-in-Swift-4.playground/Pages/Strings.xcplaygroundpage/Contents.swift
+++ b/Whats-new-in-Swift-4.playground/Pages/Strings.xcplaygroundpage/Contents.swift
@@ -9,7 +9,7 @@
  
  [SE-0168]: https://github.com/apple/swift-evolution/blob/master/proposals/0168-multi-line-string-literals.md "Swift Evolution Proposal SE-0168: Multi-Line String Literals"
  */
-let multilineString = """
+    let multilineString = """
     This is a multi-line string.
     You don't have to escape "quotes" in here.
     The position of the closing delimiter
@@ -38,7 +38,7 @@ for char in greeting {
 /*:
  ### `Substring` is the new type for string slices
 
- String slices are now instances of type `Substring`. Both `String` and `Substring` conform to `StringProtocol`. Almost the entire string API will live in `StringProtocol` so that `String` and `StringProtocol` behave largely the same.
+ String slices are now instances of type `Substring`. Both `String` and `Substring` conform to `StringProtocol`. Almost the entire string API will live in `StringProtocol` so that `String` and `Substring` behave largely the same.
  */
 let comma = greeting.index(of: ",")!
 let substring = greeting[..<comma]


### PR DESCRIPTION
looks like this should be String and Substring, not String and StringProtocol. 

that line 12 edit wasn't manual, only notice it in this pull request. possible side effect of switching between raw and rendered markup.