### PR TITLE
remove unnecessary indirection

### DIFF
--- a/Whats-new-in-Swift-4.playground/Pages/Generic subscripts.xcplaygroundpage/Contents.swift
+++ b/Whats-new-in-Swift-4.playground/Pages/Generic subscripts.xcplaygroundpage/Contents.swift
@@ -34,7 +34,7 @@ let population: Int? = json["population"]
  Another example: a subscript on `Collection` that takes a generic sequence of indices and returns an array of the values at these indices:
  */
 extension Collection {
-    subscript<Indices: Sequence>(indices indices: Indices) -> [Iterator.Element] where Indices.Iterator.Element == Index {
+    subscript<Indices: Sequence>(indices indices: Indices) -> [Element] where Indices.Element == Index {
         var result: [Element] = []
         for index in indices {
             result.append(self[index])

--- a/Whats-new-in-Swift-4.playground/Pages/reduce with inout.xcplaygroundpage/Contents.swift
+++ b/Whats-new-in-Swift-4.playground/Pages/reduce with inout.xcplaygroundpage/Contents.swift
@@ -10,9 +10,9 @@
  SE-0171 is not implemented yet.
  */
 // Not implemented yet
-//extension Sequence where Iterator.Element: Equatable {
-//    func uniq() -> [Iterator.Element] {
-//        return reduce(into: []) { (result: inout [Iterator.Element], element) in
+//extension Sequence where Element: Equatable {
+//    func uniq() -> [Element] {
+//        return reduce(into: []) { (result: inout [Element], element) in
 //            if result.last != element {
 //                result.append(element)
 //            }


### PR DESCRIPTION
'Sequence' has an 'Element' typealias as of apple/swift#9589, which was first included in a Swift 4 snapshot on 2017-05-15-a.