### PR TITLE
Fix optional

### DIFF
--- a/Whats-new-in-Swift-4.playground/Pages/Composing classes and protocols.xcplaygroundpage/Contents.swift
+++ b/Whats-new-in-Swift-4.playground/Pages/Composing classes and protocols.xcplaygroundpage/Contents.swift
@@ -16,7 +16,7 @@ class ViewController: NSViewController {
 
     init(header: NSView & HeaderView) {
         self.header = header
-        super.init(nibName: nil, bundle: nil)!
+        super.init(nibName: nil, bundle: nil)
     }
 
     required init(coder decoder: NSCoder) {


### PR DESCRIPTION
In Xcode 9, Beta 2, `NSViewController(nibName:bundle:)` is no longer a failable initializer.