### PR TITLE
Print out result of `FilteredSet` missing.

### DIFF
--- a/Whats-new-in-Swift-4.playground/Pages/Dictionary and Set enhancements.xcplaygroundpage/Contents.swift
+++ b/Whats-new-in-Swift-4.playground/Pages/Dictionary and Set enhancements.xcplaygroundpage/Contents.swift
@@ -71,6 +71,7 @@ mapped
 let set: Set = [1,2,3,4,5]
 let filteredSet = set.filter { $0 % 2 == 0 }
 type(of: filteredSet)
+filteredSet
 
 /*:
  ### Grouping a sequence


### PR DESCRIPTION
The result of `filteredSet` example is missing. I added it.

If you updated the code for a more recent Swift toolchain, did you remember to also update the "Latest toolchain tested" date on the first page of the playground? That would be rad.

Thank you so much!
